### PR TITLE
[codex] Add image hotlink protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@
 
 > **注意**：Vercel 部署时，`npm run build` 会自动扫描 `static/image/` 目录并生成 `photos.json`，无需手动操作。
 
+## 图片防盗链
+
+本站对 `/image/` 路径下的图片和图标启用了基于 `Referer` 的防盗链：
+
+- 拦截无 `Referer` 的请求，因此直接打开图片 URL 会返回 `403 Forbidden`。
+- 允许同域请求，以及 `xiayan.icu`、`*.xiayan.icu`、`xiayan.haitang000.top`、`*.xiayan.haitang000.top`、`localhost`、`127.0.0.1`。
+- 其他外站页面直接引用图片时会返回 `403 Forbidden`。
+- Docker/Nginx 部署使用 Nginx 原生规则；Vercel 部署使用 Routing Middleware，因此会产生少量边缘中间件调用。
+- 如果浏览器或代理隐藏 `Referer`，图片可能无法加载；这是严格防盗链策略的预期取舍。
+
 ## 将图片修改为自己喜欢的角色
 
 如果想要将图片修改为自己喜欢的角色，可以在`/static`目录中将图片替换，无需重命名, 正常运行命令后会自动排列照片。如果想要修改网站 Icon，可以在`/static`目录中将`logo.jpg`更换为自己喜欢的图片

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,62 @@
+import { next } from '@vercel/functions';
+
+const ALLOWED_HOSTNAMES = [
+    'xiayan.icu',
+    'www.xiayan.icu',
+    'xiayan.haitang000.top',
+    'localhost',
+    '127.0.0.1',
+];
+
+function normalizeHostname(hostname) {
+    return hostname.toLowerCase();
+}
+
+function isAllowedConfiguredHost(hostname) {
+    if (ALLOWED_HOSTNAMES.includes(hostname)) {
+        return true;
+    }
+
+    return hostname.endsWith('.xiayan.icu') || hostname.endsWith('.xiayan.haitang000.top');
+}
+
+function isAllowedImageReferer(request) {
+    const referer = request.headers.get('referer');
+
+    if (!referer) {
+        return false;
+    }
+
+    let refererUrl;
+    let requestUrl;
+
+    try {
+        refererUrl = new URL(referer);
+        requestUrl = new URL(request.url);
+    } catch {
+        return false;
+    }
+
+    const refererHost = normalizeHostname(refererUrl.hostname);
+    const requestHost = normalizeHostname(requestUrl.hostname);
+
+    return refererHost === requestHost || isAllowedConfiguredHost(refererHost);
+}
+
+export const config = {
+    matcher: '/image/:path*',
+};
+
+export default function middleware(request) {
+    if (isAllowedImageReferer(request)) {
+        return next();
+    }
+
+    return new Response('Forbidden', {
+        status: 403,
+        headers: {
+            'content-type': 'text/plain; charset=utf-8',
+            'cache-control': 'no-store',
+        },
+    });
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -74,6 +74,17 @@ http {
         # 现在：immutable 告知浏览器文件内容在有效期内绝对不会改变，跳过条件请求
         # 注意：仅对带内容哈希的文件名（如 xxx.abc123.js）适用 immutable；
         #       图片文件名不含哈希，但本站图片内容固定，30d immutable 是合理选择
+        location ~* ^/image/.*\.(jpg|jpeg|png|gif|webp|ico|svg)$ {
+            valid_referers server_names xiayan.icu *.xiayan.icu xiayan.haitang000.top *.xiayan.haitang000.top localhost 127.0.0.1;
+            if ($invalid_referer) {
+                return 403;
+            }
+
+            expires 30d;
+            add_header Cache-Control "public, no-transform, immutable";
+            access_log off;
+        }
+
         location ~* \.(jpg|jpeg|png|gif|ico|svg|woff|woff2|ttf|otf|eot)$ {
             expires 30d;
             add_header Cache-Control "public, no-transform, immutable";

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "engines": {
     "node": ">=14.0.0"
   },
+  "dependencies": {
+    "@vercel/functions": "^3.7.1"
+  },
   "license": "GPL-3.0"
 }


### PR DESCRIPTION
## Summary
- add Nginx referer checks for /image/ assets
- add Vercel Routing Middleware hotlink protection
- block direct image URL access by rejecting requests without a Referer
- document allowed referer behavior and Vercel middleware impact

## Validation
- npm run build
- node --check middleware.js
- middleware referer branch test for empty, same-host, allowlisted, external, and invalid referers

Note: nginx/docker runtime validation was not run locally because those commands are not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added referer-based image hotlink protection for `/image/`.
  * Requests with missing/invalid referers are blocked with `403 Forbidden`; allowed requests proceed and are returned with long-lived caching (`Cache-Control: immutable`).
* **Documentation**
  * Documented the referer rules for image access, including deployment differences (Docker/Nginx vs Vercel) and how no-`Referer` requests are handled.
  * Updated GPL 3.0 license guidance: violation terminates rights, with recovery via compliance.
* **Chores**
  * Pinned `@vercel/functions` to `^3.7.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->